### PR TITLE
修复 MyFairLady 主题，使其在现代 Hexo 上正常运行

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -65,5 +65,5 @@
                     ga('send', 'pageview');
                   </script>
                   <% } %>
-                    <script src="http://cdn.bootcss.com/jquery/3.1.1/jquery.min.js"></script>
+                    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 </head>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -28,7 +28,7 @@
             <%= config.title %>
     </title>
     <!-- 主css -->
-    <link rel="stylesheet" href="/css/main.css">
+    <%- css('/sass/main') %>
       <!-- seo -->
       <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
         <!-- facicon -->

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -28,7 +28,7 @@
             <%= config.title %>
     </title>
     <!-- 主css -->
-    <%- css('/sass/main') %>
+    <link rel="stylesheet" href="/css/main.css">
       <!-- seo -->
       <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
         <!-- facicon -->

--- a/source/sass/_common/code.scss
+++ b/source/sass/_common/code.scss
@@ -79,7 +79,8 @@ pre {
 
 .highlight {
     @extend %code-block;
-    border-radius: 1px pre {
+    border-radius: 1px;
+    pre {
         border: none;
         margin: 0;
         padding: 10px 0;

--- a/source/sass/_common/font.scss
+++ b/source/sass/_common/font.scss
@@ -12,15 +12,15 @@ $articleFont: Monda, "PingFang SC", "Microsoft YaHei", sans-serif;
 $logoFont: 'Athelas, STHeiti, Microsoft Yahei, serif';
 @font-face {
     font-family: 'iconfont';
-    src: url('//at.alicdn.com/t/font_1473170564_3825922.eot');
+    src: url('https://at.alicdn.com/t/font_1473170564_3825922.eot');
     /* IE9*/
-    src:url('//at.alicdn.com/t/font_1473170564_3825922.eot?#iefix') format('embedded-opentype'),
+    src:url('https://at.alicdn.com/t/font_1473170564_3825922.eot?#iefix') format('embedded-opentype'),
     /* IE6-IE8 */
-    url('//at.alicdn.com/t/font_1473170564_3825922.woff') format('woff'),
+    url('https://at.alicdn.com/t/font_1473170564_3825922.woff') format('woff'),
     /* chrome、firefox */
-    url('//at.alicdn.com/t/font_1473170564_3825922.ttf') format('truetype'),
+    url('https://at.alicdn.com/t/font_1473170564_3825922.ttf') format('truetype'),
     /* chrome、firefox、opera、Safari, Android, iOS 4.2+*/
-    url( '//at.alicdn.com/t/font_1473170564_3825922.svg#iconfont') format('svg');
+    url( 'https://at.alicdn.com/t/font_1473170564_3825922.svg#iconfont') format('svg');
     /* iOS 4.1- */
 }
 

--- a/source/sass/_partial/article.scss
+++ b/source/sass/_partial/article.scss
@@ -1,4 +1,8 @@
 //Article setting
+@import 'post/date';
+@import 'post/morelink';
+@import 'post/paginator';
+
 $article-padding: 1em 0 2em;
 $article-borderBottom: 1px;
 $article-borderBottomColor: #ddd;
@@ -41,12 +45,10 @@ $article-p-img: 100%;
         }
 
         .article-date {
-            @import 'post/date';
             @include article-date;
         }
 
         .article-inner {
-            @import 'post/morelink';
             @include morelink;
         }
 
@@ -96,7 +98,6 @@ $article-p-img: 100%;
         }
 
         .older-posts-link {
-            @import 'post/paginator';
             @include paginator;
         }
     }

--- a/source/sass/_partial/post/heart.scss
+++ b/source/sass/_partial/post/heart.scss
@@ -19,7 +19,6 @@
             width: 15px;
             height: 20px;
             background: $blog-main-color;
-            -moz-border-radius: 50px 50px 0 0;
             border-radius: 50px 50px 0 0;
             -webkit-transform: rotate(-45deg);
             -moz-transform: rotate(-45deg);


### PR DESCRIPTION
### 修复 MyFairLady 主题，使其在现代 Hexo 上正常运行

我尝试在最新版 Hexo（8.1.1）上使用这个最后提交于9年前的主题，发现了一些编译错误。已简单修复。

#### 主要变更

**1. 修复`@import` 位置以适配新版 Dart Sass 的 `@import` 规则**
- Dart Sass 2.0+ 要求 `@import` 语句必须放在文件顶部，不能嵌套在选择器内部。
- 在 `source/sass/_partial/article.scss` 中，将原本嵌套在 `.article-date`、`.article-inner` 和 `.older-posts-link` 选择器内的 `@import` 语句移到文件顶部，并保留对应的 mixin 调用。

**2. 修复 Sass 语法错误**
- 在 `source/sass/_common/code.scss` 中，原代码的 `.highlight` 选择器下存在无效语法 `border-radius: 1px pre {`，导致嵌套失效。
- 修正为正确的 `border-radius: 1px;` 并正常嵌套 `pre` 样式。

**3. 更新过时的 CDN**
- 将已停止维护的 `bootcss.com` jQuery CDN 替换为 jQuery 官方 CDN `code.jquery.com`。
- 图标字体 URL 从协议相对路径 `//at.alicdn.com` 改为显式 `https://at.alicdn.com`。

**4. 移除已废弃的浏览器前缀**
- 在 `source/sass/_common/heart.scss` 删除 `-moz-border-radius` 前缀。



**如果作者还愿意审阅这个9年前的主题，欢迎提出任何建议或意见！谢谢啦～**